### PR TITLE
Avoid infinite recursion with recursive types and compiler cache

### DIFF
--- a/src/tink/syntaxhub/FrontendContext.hx
+++ b/src/tink/syntaxhub/FrontendContext.hx
@@ -113,7 +113,7 @@ class FrontendContext {
     }
     var exists =
       try {
-        Context.getModule(actual);
+        Context.getType(actual);
         true;
       }
       catch (e:Dynamic) false;

--- a/src/tink/syntaxhub/FrontendContext.hx
+++ b/src/tink/syntaxhub/FrontendContext.hx
@@ -100,11 +100,18 @@ class FrontendContext {
 	}
 	
 	static function moduleForType(name:String) {
-		if (name.indexOf('__impl') != -1 || plugins.getData().length == 0) return None;
+		if (name.indexOf('__impl') != -1 || plugins.getData().length == 0) return;
 		var pack = name.split('.');
-		var name = pack.pop();
-		var actual = pack.concat(['__impl', name]).join('.');
-		var exists = 
+		var tname = pack.pop();
+		var actual = pack.concat(['__impl', tname]).join('.');
+		cache[name] = {
+			pack: pack,
+			name: tname,
+			pos: Context.currentPos(),
+			fields: [],
+			kind: TDAlias(actual.asComplexType())
+		}
+		var exists =
 			try {
 				Context.getModule(actual);
 				true;
@@ -112,9 +119,12 @@ class FrontendContext {
 			catch (e:Dynamic) false;
 		
 		if (!exists) {
-			var module = buildModule(pack, name);
-			if (module.types.length == 0) return None;
-			
+			var module = buildModule(pack, tname);
+			if (module.types.length == 0) {
+				cache.remove(name);
+				return;
+			}
+
 			var imports = [],
 					usings = [];
 					
@@ -131,34 +141,18 @@ class FrontendContext {
 			Context.defineModule(actual, module.types, imports, usings);
 			for (d in module.dependencies)
 				Context.registerModuleDependency(actual, d);
-		}	
-		return Some(actual);
+		}
 	}
-  
-	static var cache;
+
+	static var cache:Map<String,TypeDefinition>;
 	static public function resetCache()
     cache = new Map();
     
 	@:noDoc
-	static public function findType(name:String):TypeDefinition 
-		return 
-      if (cache.exists(name))
-        cache[name];
-      else 
-        cache[name] =           
-          switch moduleForType(name) {
-            case Some(actual):
-              var pack = name.split('.');
-              var name = pack.pop();
-              {
-                pack: pack,
-                name: name, 
-                pos: Context.currentPos(),
-                fields: [],
-                kind: TDAlias(actual.asComplexType())
-              }
-            case None: 
-              null;
-          }
-		
+	static public function findType(name:String):TypeDefinition  {
+		if (!cache.exists(name))
+			moduleForType(name);
+		return cache[name];
+	}
+
 }

--- a/src/tink/syntaxhub/FrontendContext.hx
+++ b/src/tink/syntaxhub/FrontendContext.hx
@@ -121,7 +121,7 @@ class FrontendContext {
 		if (!exists) {
 			var module = buildModule(pack, tname);
 			if (module.types.length == 0) {
-				cache.remove(name);
+				cache[name] = null;  // clean the entry, but not in a way we would try to build this again
 				return;
 			}
 


### PR DESCRIPTION
When using the compilation server and tink templates that reference other tink templates, we would get [stack overflows](https://twitter.com/jonasmalaco/status/705736233281036288).

By abusing a bit the syntaxhub type definition cache, we can mark types that are already being built and that will eventually be available, and avoid an infinite recursion in `findType`.

This has been used on [sapo](https://github.com/jonasmalacofilho/sapood) for a few months, so far without undesired side-effects.
