### PR TITLE
Don't add build meta twice

### DIFF
--- a/src/tink/SyntaxHub.hx
+++ b/src/tink/SyntaxHub.hx
@@ -15,6 +15,8 @@ using haxe.macro.Tools;
 class SyntaxHub {
   
   static var MAIN:Null<String> = null;
+  static var addedMeta = false;
+  
   static function use() {
     var args = Sys.args();
     
@@ -27,7 +29,11 @@ class SyntaxHub {
     FrontendContext.resetCache();
     classLevel.whenever(makeSyntax(exprLevel.appliedTo), exprLevel.id);//Apperently reinserting this every time is more reliable with the cache
     Context.onTypeNotFound(FrontendContext.findType);
-    Compiler.addGlobalMetadata('', '@:build(tink.SyntaxHub.build())', true, true, false);
+    
+    if(!addedMeta) {
+      addedMeta = true;
+      Compiler.addGlobalMetadata('', '@:build(tink.SyntaxHub.build())', true, true, false);
+    }
 
   }
   


### PR DESCRIPTION
Somehow this happens when both myself and a dependency library depend on syntaxhub;

e.g.

```
       tink_unittest's test 
        /             \
   tink_await      tink_unittest
       |               |
 tink_syntaxhub    tink_syntaxhub
```

This will cause the `SyntaxHub.use()` run twice and thus those `@:build` meta added twice